### PR TITLE
required cli arguments are positional arguments instead of flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ When deployed to a cloud provider using Terraform you can inspect the resulting 
 ### Start a docker-based app:
 
 ```
-ltc start APP_NAME -i DOCKER_IMAGE
+ltc start APP_NAME DOCKER_IMAGE
 ```
 
 will start a Dockerimage-based application on Lattice.
@@ -80,7 +80,7 @@ will start a Dockerimage-based application on Lattice.
 We have a simple demo-application that you can play with:
 
 ```
-ltc start lattice-app -i docker:///cloudfoundry/lattice-app
+ltc start lattice-app docker:///cloudfoundry/lattice-app
 ```
 
 `ltc help start` documents a number of useful options for starting your application.
@@ -116,13 +116,13 @@ Will print an ascii-art representation of the distribution of containers across 
 ### Example Usage:
 
     ltc target 192.168.11.11.xip.io
-    ltc start lattice-app -i "docker:///cloudfoundry/lattice-app"
+    ltc start lattice-app docker:///cloudfoundry/lattice-app
     ltc logs lattice-app
 
 To view the app in a browser visit http://lattice-app.192.168.11.11.xip.io/
 
 To scale up the app:
 
-    ltc scale lattice-app -i 5
+    ltc scale lattice-app 5
 
 Refresh the browser to see the requests routing to different Docker containers running lattice-app.

--- a/app_runner/command_factory/app_runner_command_factory.go
+++ b/app_runner/command_factory/app_runner_command_factory.go
@@ -2,6 +2,7 @@ package command_factory
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,10 +37,6 @@ func NewAppRunnerCommandFactory(config AppRunnerCommandFactoryConfig) *AppRunner
 func (commandFactory *AppRunnerCommandFactory) MakeStartAppCommand() cli.Command {
 
 	var startFlags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "docker-image, i",
-			Usage: "docker image to run",
-		},
 		cli.StringFlag{
 			Name:  "working-dir, w",
 			Usage: "working directory to assign to the running process",
@@ -79,7 +76,7 @@ func (commandFactory *AppRunnerCommandFactory) MakeStartAppCommand() cli.Command
 	var startCommand = cli.Command{
 		Name:      "start",
 		ShortName: "s",
-		Usage:     "ltc start APP_NAME -i DOCKER_IMAGE",
+		Usage:     "ltc start APP_NAME DOCKER_IMAGE",
 		Description: `Start a docker app on lattice
    
    APP_NAME is required and must be unique across the Lattice cluster
@@ -88,10 +85,10 @@ func (commandFactory *AppRunnerCommandFactory) MakeStartAppCommand() cli.Command
 
    ltc will fetch the command associated with your Docker image.
    To provide a custom command:
-   ltc start APP_NAME -i DOCKER_IMAGE -- START_COMMAND APP_ARG1 APP_ARG2 ...
+   ltc start APP_NAME DOCKER_IMAGE <optional flags> -- START_COMMAND APP_ARG1 APP_ARG2 ...
 
    To specify environment variables:
-   ltc start APP_NAME -i DOCKER_IMAGE -e FOO=BAR -e BAZ=WIBBLE`,
+   ltc start APP_NAME DOCKER_IMAGE -e FOO=BAR -e BAZ=WIBBLE`,
 		Action: commandFactory.appRunnerCommand.startApp,
 		Flags:  startFlags,
 	}
@@ -100,20 +97,11 @@ func (commandFactory *AppRunnerCommandFactory) MakeStartAppCommand() cli.Command
 }
 
 func (commandFactory *AppRunnerCommandFactory) MakeScaleAppCommand() cli.Command {
-
-	var scaleFlags = []cli.Flag{
-		cli.IntFlag{
-			Name:  "instances, i",
-			Usage: "the number of instances to scale to",
-		},
-	}
-
 	var scaleCommand = cli.Command{
 		Name:        "scale",
 		Description: "Scale a docker app on lattice",
-		Usage:       "ltc scale APP_NAME --instances NUM_INSTANCES",
+		Usage:       "ltc scale APP_NAME NUM_INSTANCES",
 		Action:      commandFactory.appRunnerCommand.scaleApp,
-		Flags:       scaleFlags,
 	}
 
 	return scaleCommand
@@ -134,7 +122,6 @@ func (commandFactory *AppRunnerCommandFactory) MakeStopAppCommand() cli.Command 
 }
 
 func (commandFactory *AppRunnerCommandFactory) MakeRemoveAppCommand() cli.Command {
-
 	var removeCommand = cli.Command{
 		Name:        "remove",
 		Description: "Stop and remove a docker app from lattice",
@@ -156,7 +143,6 @@ type appRunnerCommand struct {
 }
 
 func (cmd *appRunnerCommand) startApp(context *cli.Context) {
-	dockerImage := context.String("docker-image")
 	workingDir := context.String("working-dir")
 	envVars := context.StringSlice("env")
 	privileged := context.Bool("run-as-root")
@@ -165,8 +151,9 @@ func (cmd *appRunnerCommand) startApp(context *cli.Context) {
 	diskMB := context.Int("disk-mb")
 	port := context.Int("port")
 	name := context.Args().Get(0)
-	terminator := context.Args().Get(1)
-	startCommand := context.Args().Get(2)
+	dockerImage := context.Args().Get(1)
+	terminator := context.Args().Get(2)
+	startCommand := context.Args().Get(3)
 
 	var appArgs []string
 
@@ -174,7 +161,7 @@ func (cmd *appRunnerCommand) startApp(context *cli.Context) {
 	case name == "":
 		cmd.output.IncorrectUsage("App Name required")
 		return
-	case dockerImage == "":
+	case dockerImage == "" || dockerImage == "--":
 		cmd.output.IncorrectUsage("Docker Image required")
 		return
 	case !strings.HasPrefix(dockerImage, "docker:///"):
@@ -183,8 +170,8 @@ func (cmd *appRunnerCommand) startApp(context *cli.Context) {
 	case startCommand != "" && terminator != "--":
 		cmd.output.IncorrectUsage("'--' Required before start command")
 		return
-	case len(context.Args()) > 3:
-		appArgs = context.Args()[3:]
+	case len(context.Args()) > 4:
+		appArgs = context.Args()[4:]
 	case startCommand == "":
 		cmd.output.Say("No start command specified, fetching metadata from the Dockerimage...\n")
 
@@ -245,13 +232,20 @@ func (cmd *appRunnerCommand) startApp(context *cli.Context) {
 
 func (cmd *appRunnerCommand) scaleApp(c *cli.Context) {
 	appName := c.Args().First()
-	instances := c.Int("instances")
+	instancesArg := c.Args().Get(1)
 
-	if appName == "" {
+	switch {
+	case appName == "":
 		cmd.output.IncorrectUsage("App Name required")
 		return
-	} else if !c.IsSet("instances") {
+	case instancesArg == "":
 		cmd.output.IncorrectUsage("Number of Instances Required")
+		return
+	}
+
+	instances, err := strconv.Atoi(instancesArg)
+	if err != nil {
+		cmd.output.IncorrectUsage("Number of Instances must be an integer")
 		return
 	}
 


### PR DESCRIPTION
This PR turns

```
ltc start APP_NAME -i DOCKER_IMAGE
ltc scale APP_NAME --instances 5
```

into

```
ltc start APP_NAME DOCKER_IMAGE
ltc scale APP_NAME 5
```

I've updated the docs -- I imagine whetstone will need to be updated.  Also @jbayer will need to update his getting started document
