### PR TITLE
Remove docker:/// prefix from app tags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ will start a Dockerimage-based application on Lattice.
 We have a simple demo-application that you can play with:
 
 ```
-ltc start lattice-app docker:///cloudfoundry/lattice-app
+ltc start lattice-app cloudfoundry/lattice-app
 ```
 
 `ltc help start` documents a number of useful options for starting your application.
@@ -116,7 +116,7 @@ Will print an ascii-art representation of the distribution of containers across 
 ### Example Usage:
 
     ltc target 192.168.11.11.xip.io
-    ltc start lattice-app docker:///cloudfoundry/lattice-app
+    ltc start lattice-app cloudfoundry/lattice-app
     ltc logs lattice-app
 
 To view the app in a browser visit http://lattice-app.192.168.11.11.xip.io/


### PR DESCRIPTION
The CLI doesn't seem to support this. See the
[lattice-app](https://github.com/pivotal-cf-experimental/lattice-app) README
for another example of this usage.
